### PR TITLE
Correction of setcredentials syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Translate documents:
 
 Set credentials:
 
-`DocumentTranslatorCmd setcredentials /azurekey:AzureKey`
+`DocumentTranslatorCmd setcredentials /APIkey:AzureKey`
 
 Get Word Alignments
 


### PR DESCRIPTION
The correct command is 
DocumentTranslatorCmd setcredentials /APIkey:
not
DocumentTranslatorCmd setcredentials /azurekey: