### PR TITLE
Adding 'office' to references

### DIFF
--- a/TranslationAssistant.Business/TranslationAssistant.Business.csproj
+++ b/TranslationAssistant.Business/TranslationAssistant.Business.csproj
@@ -40,6 +40,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Office, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />


### PR DESCRIPTION
DocumentTranslator by default links to `Microsoft.Office.Core` which is included with Microsoft Office.  Microsoft also provides a similar library in the `Office/SharePoint` development resource that is available in the Visual Studio Installer.

With this change, users that don't have Microsoft Office can still build DocumentTranslator.