### PR TITLE
break AddNodes loop if child is null

### DIFF
--- a/TranslationAssistant.Business/HTMLTranslationManager.cs
+++ b/TranslationAssistant.Business/HTMLTranslationManager.cs
@@ -57,7 +57,7 @@ namespace TranslationAssistant.Business
         {
             string[] DNTList = { "script", "#text", "code", "col", "colgroup", "embed", "em", "#comment", "image", "map", "media", "meta", "source", "xml"};  //DNT - Do Not Translate - these nodes are skipped.
             HtmlNode child = rootnode;
-            while (child != rootnode.LastChild)
+            while (child != null && child != rootnode.LastChild)
             {
                 if (!DNTList.Contains(child.Name.ToLowerInvariant())) {
                     if (child.InnerHtml.Length > maxRequestSize)


### PR DESCRIPTION
When translating a particular HTML file I hit the `Object Reference not set to an instance of an object` error reported here: https://github.com/MicrosoftTranslator/DocumentTranslator/issues/52
After getting my environment setup I ran the program in debugging mode and found it was breaking on the line:
`if (!DNTList.Contains(child.Name.ToLowerInvariant())) {`
It appears a particular element in the document was showing the `rootnode.LastChild` as a `#text` element, but that did not appear to exist in the document, so this loop just kept going until `child` became `null`, causing the error above when calling `child.Name`.
This simple change will cause AddNodes to break out of the loop if `child` is null, and I have verified after making this change it is able to translate the file that was consistently failing for me before.